### PR TITLE
Enable CI/CD pipelines

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,89 @@
+name: gh
+
+on:
+  create:  # is used for publishing to PyPI and TestPyPI
+    tags:  # any tag regardless of its name, no branches
+  push:  # only publishes pushes to the main branch to TestPyPI
+    branches:  # any branch but not tag
+    - >-
+      **
+    tags-ignore:
+    - >-
+      **
+  pull_request:
+  schedule:
+  - cron: 1 0 * * *  # Run daily at 0:01 UTC
+  # Run every Friday at 18:02 UTC
+  # https://crontab.guru/#2_18_*_*_5
+  # - cron: 2 18 * * 5
+
+jobs:
+  gh:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: linters
+          python-version: 3.6
+          continue-on-error: true
+        - name: docs
+          python-version: 3.6
+          continue-on-error: true
+        - name: py36
+          python-version: 3.6
+        - name: py37
+          python-version: 3.7
+        - name: py38
+          python-version: 3.8
+        - name: py39
+          python-version: 3.9-dev
+    steps:
+    - uses: actions/checkout@master
+    - name: Get history and tags for SCM versioning to work
+      run: |
+        git fetch --prune --unshallow
+        git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+    - name: Set up stock Python ${{ matrix.python-version }} from GitHub
+      if: >-
+        !endsWith(matrix.python-version, '-dev')
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} from deadsnakes
+      if: >-
+        endsWith(matrix.python-version, '-dev')
+      uses: deadsnakes/action@v1.0.0
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: >-
+        Log the currently selected Python
+        version info (${{ matrix.python-version }})
+      run: |
+        python --version --version
+        which python
+    - name: Pip cache
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ env.PY_SHA256 }}-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pytest.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+          ${{ runner.os }}-
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade tox
+    - name: Log installed dists
+      run: >-
+        python -m pip freeze --all
+    - name: "Test with tox"
+      run: |
+        python -m tox
+      env:
+        TOXENV: ${{ matrix.name }}
+    - name: Archive logs
+      uses: actions/upload-artifact@v2
+      with:
+        name: logs.zip
+        path: .tox/**/log/

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-# toxworkdir = /data1/DATA/tox/ruamel.yaml 
-envlist = cs,py37,py27,py36,py35,py38,py39,pypy,py27m
+# toxworkdir = /data1/DATA/tox/ruamel.yaml
+envlist = linters,docs,py36,py37,py38,py39
 
 [testenv]
 commands =
@@ -9,18 +9,17 @@ deps =
     pytest
     ruamel.std.pathlib
 
-[testenv:py27m]
-basepython = /opt/python/2.7.15m/bin/python
-
-[testenv:cs]
+[testenv:docs]
 basepython = python3.6
 deps =
-    flake8
-    flake8-bugbear;python_version>="3.5"
+    Sphinx
 commands =
-    flake8 []{posargs}
+    make singlehtml
+changedir = {toxinidir}/_doc
+whitelist_externals =
+    make
 
-[testenv:pep8]
+[testenv:linters]
 basepython = python3.6
 deps =
     flake8


### PR DESCRIPTION
- adds jobs for versions we want to support
- updates to tox
- renames cs/pep8 toxenv to "linters" which describes better its
  purpose